### PR TITLE
Sample Dockerfile: put comment in a separate line

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,9 @@ docker pull aldor007/mort
 Create Dockerfile or use Dockerfile.service
 ```
 FROM aldor007/mort:latest
-ADD config.yml /etc/mort/mort.yml # add yours config
+
+# add your config
+ADD config.yml /etc/mort/mort.yml 
 ```
 
 Build container


### PR DESCRIPTION
The provided sample is not a valid Dockerfile

> Docker treats lines that begin with # as a comment, unless the line is a valid parser directive. A # marker anywhere else in a line is treated as an argument.